### PR TITLE
Avoid PDF/A-3 test failure

### DIFF
--- a/src/PdfSharp/Pdf.Advanced/PdfCIDFont.cs
+++ b/src/PdfSharp/Pdf.Advanced/PdfCIDFont.cs
@@ -53,6 +53,7 @@ namespace PdfSharp.Pdf.Advanced
             cid.Elements.SetString("/Registry", "Adobe");
             cid.Elements.SetInteger("/Supplement", 0);
             Elements.SetValue(Keys.CIDSystemInfo, cid);
+            this.Elements.SetName(Keys.CIDToGIDMap, "/Identity");
 
             FontDescriptor = fontDescriptor;
             // ReSharper disable once DoNotCallOverridableMethodsInConstructor
@@ -72,6 +73,7 @@ namespace PdfSharp.Pdf.Advanced
             cid.Elements.SetString("/Registry", "Adobe");
             cid.Elements.SetInteger("/Supplement", 0);
             Elements.SetValue(Keys.CIDSystemInfo, cid);
+            this.Elements.SetName(Keys.CIDToGIDMap, "/Identity");
 
             FontDescriptor = fontDescriptor;
             // ReSharper disable once DoNotCallOverridableMethodsInConstructor


### PR DESCRIPTION
Avoid PDF/A-3 test failure (ISO 32000-1:2008, 9.7.4, Table 117 requires that all embedded Type 2 CIDFonts in the CIDFont dictionary shall contain a CIDToGIDMap entry that shall be a stream mapping from CIDs to glyph indices or the name Identity, as described in ISO 32000-1:2008, 9.7.4, Table 117)

There's no easy way to do it otherwise. This is what works, but it is really ugly
```chsarp
			// HACK: Add required /CIDToGIDMap /Identity to fonts
			//var fontTable = document.FontTable;
			//var documentFonts = fontTable._fonts;
			var fontTableProperty = typeof(PdfDocument).GetProperty("FontTable", BindingFlags.NonPublic | BindingFlags.Instance);
			object fontTable = fontTableProperty.GetValue(document, null);
			var fontsField = fontTable.GetType().GetField("_fonts", BindingFlags.NonPublic | BindingFlags.Instance);
			var documentFonts = (IDictionary<string, PdfFont>)fontsField.GetValue(fontTable);
			foreach (var documentFont in documentFonts.Values)
			{
				if (documentFont.Elements.TryGetValue("/DescendantFonts", out PdfItem descendantFontItem))
				{
					PdfArray descendantFont = (PdfArray)descendantFontItem;
					var descendantFontDictionary = (PdfDictionary)((PdfReference)descendantFont.Elements[0]).Value;
					descendantFontDictionary.Elements.SetName("/CIDToGIDMap", "/Identity");
				}
			}
```